### PR TITLE
Fixed promise rejection error when username was updated on EditDetails Component

### DIFF
--- a/Components/EditDetails.jsx
+++ b/Components/EditDetails.jsx
@@ -19,6 +19,7 @@ export default function EditDetails({
   );
   const { editUser, logout } = useContext(UserContext);
   const navigation = useNavigation();
+  const [displayText, setDisplayText] = useState("");
 
   if (!avatars) {
     avatars = [];
@@ -34,13 +35,21 @@ export default function EditDetails({
       email: newEmail,
       avatar_id: selectedAvatarId,
     };
-    await editUser(patchBody).then(() => {
-      if (userDetails.username !== patchBody.username) {
-        logout(navigation);
-      }
-      setEditingMode(false);
-      setUpdatedDetails(true);
-    });
+    await editUser(patchBody)
+      .then(() => {
+        if (userDetails.username !== patchBody.username) {
+          setDisplayText("You will be logged out for changes to take effect");
+          setTimeout(() => {
+            setEditingMode(false);
+            setDisplayText("");
+            logout(navigation);
+          }, 5000);
+        } else {
+          setEditingMode(false);
+        }
+        setUpdatedDetails(true);
+      })
+      .then(() => {});
   };
 
   return (
@@ -77,6 +86,11 @@ export default function EditDetails({
           setSelectedAvatarId(e.avatar_id);
         }}
       />
+      {displayText ? (
+        <View>
+          <Text>{displayText}</Text>
+        </View>
+      ) : null}
       <View style={styles.buttons}>
         <Button
           title="Cancel"
@@ -134,5 +148,9 @@ const styles = StyleSheet.create({
     marginTop: 5,
     fontSize: 16,
     color: "grey",
+  },
+  display_text: {
+    textAlign: "center",
+    color: "red",
   },
 });

--- a/Components/EditDetails.jsx
+++ b/Components/EditDetails.jsx
@@ -10,7 +10,7 @@ export default function EditDetails({
   setEditingMode,
   userDetails,
   avatars,
-  setUpdated,
+  setUpdatedDetails,
 }) {
   const [newUsername, setNewUsername] = useState(userDetails.username);
   const [newEmail, setNewEmail] = useState(userDetails.email);
@@ -28,20 +28,19 @@ export default function EditDetails({
     return { ...avatar, avatar_url: { uri: avatar.avatar_url } };
   });
 
-
   const saveUserDetails = async () => {
     const patchBody = {
       username: newUsername,
       email: newEmail,
       avatar_id: selectedAvatarId,
     };
-    editUser(userDetails.username, patchBody);
-    if (userDetails.username !== patchBody.username) {
-      logout(navigation);
-    }
-    setEditingMode(false);
-    setUpdated(true);
-    
+    await editUser(patchBody).then(() => {
+      if (userDetails.username !== patchBody.username) {
+        logout(navigation);
+      }
+      setEditingMode(false);
+      setUpdatedDetails(true);
+    });
   };
 
   return (

--- a/context/UserContext.jsx
+++ b/context/UserContext.jsx
@@ -40,9 +40,13 @@ export const UserProvider = ({ children }) => {
   };
 
   const editUser = async (patchBody) => {
-   await patchUserByUsername(userLogged, patchBody).catch ((err) => {
-      console.log("Error in patching user:", err);
-    })
+    await patchUserByUsername(userLogged, patchBody)
+      .then(({ modifiedUser }) => {
+        setUserLogged(modifiedUser.username);
+      })
+      .catch((err) => {
+        console.log("Error in patching user:", err);
+      });
   };
 
   const logout = async (navigation) => {


### PR DESCRIPTION
- setUpdatedDetails had been incorrectly sent down on props due to misaligned variable naming; this was corrected.
- As the user is logged out when the username is updated, text is now displayed to explain this with a 5 second pause before the log out occurs.
- the editUser function in context updates the username stored when the patch request is successful.